### PR TITLE
feat: extend `toLong()`, `toString()` and `subnet.contains()` suitable input types

### DIFF
--- a/src/main/ts/core.ts
+++ b/src/main/ts/core.ts
@@ -242,7 +242,7 @@ type Subnet = {
   subnetMaskLength: number
   numHosts: number
   length: number
-  contains(ip: string): boolean
+  contains(ip: string | BufferLike | number): boolean
 }
 
 export const subnet = (addr: string, smask: string): Subnet => {

--- a/src/main/ts/core.ts
+++ b/src/main/ts/core.ts
@@ -1,5 +1,7 @@
 import { Buffer, type BufferLike } from './buffer.ts'
 
+export type { BufferLike } from './buffer.ts'
+
 export const IPV4 = 'IPv4'
 export const IPV6 = 'IPv6'
 
@@ -123,10 +125,15 @@ export const fromLong = (n: number): string => {
   ].join('.')
 }
 
-export const toLong = (ip: string): number =>
-  ip.split('.').reduce((acc, octet) => (acc << 8) + Number(octet), 0) >>> 0
+export const toLong = (ip: string | BufferLike): number =>
+  typeof ip === 'string'
+    ? ip.split('.').reduce((acc, octet) => (acc << 8) + Number(octet), 0) >>> 0
+    : ip.length === 4
+      ? (ip[0] << 24) + (ip[1] << 16) + (ip[2] << 8) + ip[3] >>> 0
+      : -1
 
-export const toString = (buff: BufferLike, offset = 0, length?: number): string => {
+export const toString = (buff: BufferLike | number, offset = 0, length?: number): string => {
+  if (typeof buff === 'number') buff = toBuffer(buff)
   const o = ~~offset
   const l = length || (buff.length - offset)
 
@@ -145,7 +152,9 @@ export const toString = (buff: BufferLike, offset = 0, length?: number): string 
   throw new Error('Invalid buffer length for IP address')
 }
 
-export const toBuffer = (ip: string, buff?: BufferLike, offset = 0): BufferLike => {
+export const toBuffer = (ip: string | number, buff?: BufferLike, offset = 0): BufferLike => {
+  if (typeof ip === 'number') ip = fromLong(ip)
+
   offset = ~~offset
 
   if (isV4Format(ip)) {
@@ -260,18 +269,26 @@ export const subnet = (addr: string, smask: string): Subnet => {
   const lastAddress = numAddresses <= 2
     ? networkAddress + numAddresses - 1
     : networkAddress + numAddresses - 2
+  const broadcastAddress = networkAddress + numAddresses - 1
 
   return {
     networkAddress:   fromLong(networkAddress),
     firstAddress:     fromLong(firstAddress),
     lastAddress:      fromLong(lastAddress),
-    broadcastAddress: fromLong(networkAddress + numAddresses - 1),
+    broadcastAddress: fromLong(broadcastAddress),
     subnetMask:       smask,
     subnetMaskLength: maskLen,
     numHosts,
     length:           numAddresses,
-    contains(ip: string): boolean {
-      return networkAddress === toLong(mask(ip, smask))
+    contains(ip: string | number | BufferLike): boolean {
+      // return networkAddress === toLong(mask(ip, smask))
+
+      const long =
+        typeof ip === 'number' ? ip
+        : typeof ip === 'string' ? toLong(toBuffer(ip))
+          : toLong(ip)
+
+      return long >= networkAddress && long <= broadcastAddress
     },
   }
 }
@@ -316,29 +333,29 @@ export const or = (a: string, b: string): string => {
 }
 
 export const isEqual = (a: string, b: string): boolean => {
-  let ab = toBuffer(a)
-  let bb = toBuffer(b)
+  let buffA = toBuffer(a)
+  let buffB = toBuffer(b)
 
   // same protocol
-  if (ab.length === bb.length) {
-    for (let i = 0; i < ab.length; i++) {
-      if (ab[i] !== bb[i]) return false
+  if (buffA.length === buffB.length) {
+    for (let i = 0; i < buffA.length; i++) {
+      if (buffA[i] !== buffB[i]) return false
     }
     return true
   }
 
   // ensure ab is IPv4 and bb is IPv6
-  if (bb.length === 4) [ab, bb] = [bb, ab]
+  if (buffB.length === 4) [buffA, buffB] = [buffB, buffA]
 
   // first 10 bytes must be zero
-  for (let i = 0; i < 10; i++) if (bb[i] !== 0) return false
+  for (let i = 0; i < 10; i++) if (buffB[i] !== 0) return false
 
   // next 2 bytes must be either 0x0000 or 0xffff (::ffff:ipv4)
-  const prefix = bb.readUInt16BE(10)
+  const prefix = buffB.readUInt16BE(10)
   if (prefix !== 0 && prefix !== 0xffff) return false
 
   // last 4 bytes must match IPv4 buffer
-  for (let i = 0; i < 4; i++) if (ab[i] !== bb[i + 12]) return false
+  for (let i = 0; i < 4; i++) if (buffA[i] !== buffB[i + 12]) return false
 
   return true
 }

--- a/src/test/ts/core.test.ts
+++ b/src/test/ts/core.test.ts
@@ -187,6 +187,12 @@ describe('core', () => {
     assert.throws(() => toBuffer(''), /Error: invalid IP address/)
   })
 
+  test('toLong(), toString(), toBuffer() roundtrip', () => {
+    assert.deepEqual(toLong('127.0.0.1'), toLong(toBuffer('127.0.0.1')))
+    assert.equal(toLong('127.0.0.1'), toLong(toBuffer('127.0.0.1')))
+    assert.equal(toString(toBuffer(2130706433)), toString(2130706433))
+  })
+
   test('fromPrefixLen()', () => {
     const cases: [number, string, (string | number)?][] = [
       [24, '255.255.255.0'],

--- a/src/test/ts/core.test.ts
+++ b/src/test/ts/core.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert'
 import {test, describe} from 'vitest'
 
 import {
+  type BufferLike,
   normalizeFamily,
   normalizeToLong,
   IPV4,
@@ -144,9 +145,10 @@ describe('core', () => {
   })
 
   test('toLong()', () => {
-    const cases: [string, number][] = [
+    const cases: [string | BufferLike, number][] = [
       ['127.0.0.1', 2130706433],
-      ['255.255.255.255', 4294967295]
+      ['255.255.255.255', 4294967295],
+      [Buffer.from([127, 0, 0, 1]), 2130706433],
     ]
 
     for (const [input, expected] of cases) {
@@ -156,8 +158,9 @@ describe('core', () => {
 
   test('toBuffer()/toString()', () => {
     const u = undefined
-    const cases: [string, Buffer | undefined, number | undefined, number | undefined, string, string?][] = [
+    const cases: [string | number, Buffer | undefined, number | undefined, number | undefined, string, string?][] = [
       ['127.0.0.1', u, u, u, '7f000001'],
+      [2130706433, u, u, u, '7f000001'],
       ['::ffff:127.0.0.1', u, u, u, '00000000000000000000ffff7f000001', '::ffff:7f00:1'],
       ['127.0.0.1', Buffer.alloc(128), 64, 4, '0'.repeat(128) + '7f000001' + '0'.repeat(120)],
       ['::1', u, u, u, '00000000000000000000000000000001'],
@@ -172,10 +175,13 @@ describe('core', () => {
     for (const [input, b, o, l, h, s = input] of cases) {
       const buf = toBuffer(input, b, o)
       const str = toString(buf, o, l)
+      const long = toLong(buf)
       const hex = buf.toString('hex')
 
       assert.equal(hex, h, `toBuffer(${input}).toString('hex') === ${h}`)
-      assert.equal(str, s, `toString(toBuffer(${input})) === ${s}`)
+
+      if (typeof s === 'string') assert.equal(str, s, `toString(toBuffer(${input})) === ${s}`)
+      if (typeof s === 'number') assert.equal(long, s, `toLong(toBuffer(${input})) === ${s}`)
     }
 
     assert.throws(() => toBuffer(''), /Error: invalid IP address/)
@@ -208,7 +214,7 @@ describe('core', () => {
   })
 
   test('subnet()', () => {
-    const cases: [string, string, Record<string, any>, string[], string[]][] = [
+    const cases: [string, string, Record<string, any>, (string | number | BufferLike)[], (string | number | BufferLike)[]][] = [
       ['192.168.1.134', '255.255.255.192', {
         networkAddress: '192.168.1.128',
         firstAddress:   '192.168.1.129',
@@ -218,7 +224,14 @@ describe('core', () => {
         subnetMaskLength: 26,
         numHosts:      62,
         length:        64,
-      }, ['192.168.1.180'], ['192.168.1.192']],
+      }, [
+        '192.168.1.180',
+        '192.168.1.128',
+        toLong('192.168.1.180'),
+        toBuffer('192.168.1.180'),
+      ], [
+        '192.168.1.192'
+      ]],
 
       ['192.168.1.134', '255.255.255.255', {
         firstAddress: '192.168.1.134',

--- a/target/cjs/core.cjs
+++ b/target/cjs/core.cjs
@@ -172,8 +172,9 @@ var fromLong = (n) => {
     n & 255
   ].join(".");
 };
-var toLong = (ip) => ip.split(".").reduce((acc, octet) => (acc << 8) + Number(octet), 0) >>> 0;
+var toLong = (ip) => typeof ip === "string" ? ip.split(".").reduce((acc, octet) => (acc << 8) + Number(octet), 0) >>> 0 : ip.length === 4 ? (ip[0] << 24) + (ip[1] << 16) + (ip[2] << 8) + ip[3] >>> 0 : -1;
 var toString = (buff, offset = 0, length) => {
+  if (typeof buff === "number") buff = toBuffer(buff);
   const o = ~~offset;
   const l = length || buff.length - offset;
   if (l === 4)
@@ -183,6 +184,7 @@ var toString = (buff, offset = 0, length) => {
   throw new Error("Invalid buffer length for IP address");
 };
 var toBuffer = (ip, buff, offset = 0) => {
+  if (typeof ip === "number") ip = fromLong(ip);
   offset = ~~offset;
   if (isV4Format(ip)) {
     const res = buff || Buffer2.alloc(offset + 4);
@@ -260,17 +262,19 @@ var subnet = (addr, smask) => {
   const numHosts = numAddresses <= 2 ? numAddresses : numAddresses - 2;
   const firstAddress = numAddresses <= 2 ? networkAddress : networkAddress + 1;
   const lastAddress = numAddresses <= 2 ? networkAddress + numAddresses - 1 : networkAddress + numAddresses - 2;
+  const broadcastAddress = networkAddress + numAddresses - 1;
   return {
     networkAddress: fromLong(networkAddress),
     firstAddress: fromLong(firstAddress),
     lastAddress: fromLong(lastAddress),
-    broadcastAddress: fromLong(networkAddress + numAddresses - 1),
+    broadcastAddress: fromLong(broadcastAddress),
     subnetMask: smask,
     subnetMaskLength: maskLen,
     numHosts,
     length: numAddresses,
     contains(ip) {
-      return networkAddress === toLong(mask(ip, smask));
+      const long = typeof ip === "number" ? ip : typeof ip === "string" ? toLong(toBuffer(ip)) : toLong(ip);
+      return long >= networkAddress && long <= broadcastAddress;
     }
   };
 };
@@ -301,19 +305,19 @@ var or = (a, b) => {
   return toString(buffA);
 };
 var isEqual = (a, b) => {
-  let ab = toBuffer(a);
-  let bb = toBuffer(b);
-  if (ab.length === bb.length) {
-    for (let i = 0; i < ab.length; i++) {
-      if (ab[i] !== bb[i]) return false;
+  let buffA = toBuffer(a);
+  let buffB = toBuffer(b);
+  if (buffA.length === buffB.length) {
+    for (let i = 0; i < buffA.length; i++) {
+      if (buffA[i] !== buffB[i]) return false;
     }
     return true;
   }
-  if (bb.length === 4) [ab, bb] = [bb, ab];
-  for (let i = 0; i < 10; i++) if (bb[i] !== 0) return false;
-  const prefix = bb.readUInt16BE(10);
+  if (buffB.length === 4) [buffA, buffB] = [buffB, buffA];
+  for (let i = 0; i < 10; i++) if (buffB[i] !== 0) return false;
+  const prefix = buffB.readUInt16BE(10);
   if (prefix !== 0 && prefix !== 65535) return false;
-  for (let i = 0; i < 4; i++) if (ab[i] !== bb[i + 12]) return false;
+  for (let i = 0; i < 4; i++) if (buffA[i] !== buffB[i + 12]) return false;
   return true;
 };
 var isPrivate = (addr) => {

--- a/target/dts/core.d.ts
+++ b/target/dts/core.d.ts
@@ -1,4 +1,5 @@
 import { type BufferLike } from './buffer.ts';
+export type { BufferLike } from './buffer.ts';
 export declare const IPV4 = "IPv4";
 export declare const IPV6 = "IPv6";
 export declare const V4_RE: RegExp;
@@ -19,9 +20,9 @@ declare const V6_LB = "fe80::1";
 export declare const isLoopback: (addr: string | number) => boolean;
 export declare const loopback: (family?: string | number) => typeof V4_LB | typeof V6_LB;
 export declare const fromLong: (n: number) => string;
-export declare const toLong: (ip: string) => number;
-export declare const toString: (buff: BufferLike, offset?: number, length?: number) => string;
-export declare const toBuffer: (ip: string, buff?: BufferLike, offset?: number) => BufferLike;
+export declare const toLong: (ip: string | BufferLike) => number;
+export declare const toString: (buff: BufferLike | number, offset?: number, length?: number) => string;
+export declare const toBuffer: (ip: string | number, buff?: BufferLike, offset?: number) => BufferLike;
 export declare const fromPrefixLen: (prefixlen: number, family?: string | number) => string;
 export declare const mask: (addr: string, maskStr: string) => string;
 type Subnet = {
@@ -44,4 +45,3 @@ export declare const isEqual: (a: string, b: string) => boolean;
 export declare const isPrivate: (addr: string) => boolean;
 export declare const isPublic: (addr: string) => boolean;
 export declare const isSpecial: (addr: string) => boolean;
-export {};

--- a/target/dts/core.d.ts
+++ b/target/dts/core.d.ts
@@ -34,7 +34,7 @@ type Subnet = {
     subnetMaskLength: number;
     numHosts: number;
     length: number;
-    contains(ip: string): boolean;
+    contains(ip: string | BufferLike | number): boolean;
 };
 export declare const subnet: (addr: string, smask: string) => Subnet;
 export declare const cidr: (cidrString: string) => string;

--- a/target/dts/index.d.ts
+++ b/target/dts/index.d.ts
@@ -19,9 +19,9 @@ export declare const ip: {
     isLoopback: (addr: string | number) => boolean;
     loopback: (family?: string | number) => "127.0.0.1" | "fe80::1";
     fromLong: (n: number) => string;
-    toLong: (ip: string) => number;
-    toString: (buff: import("./buffer.ts").BufferLike, offset?: number, length?: number) => string;
-    toBuffer: (ip: string, buff?: import("./buffer.ts").BufferLike, offset?: number) => import("./buffer.ts").BufferLike;
+    toLong: (ip: string | core.BufferLike) => number;
+    toString: (buff: core.BufferLike | number, offset?: number, length?: number) => string;
+    toBuffer: (ip: string | number, buff?: core.BufferLike, offset?: number) => core.BufferLike;
     fromPrefixLen: (prefixlen: number, family?: string | number) => string;
     mask: (addr: string, maskStr: string) => string;
     subnet: (addr: string, smask: string) => {

--- a/target/dts/index.d.ts
+++ b/target/dts/index.d.ts
@@ -33,7 +33,7 @@ export declare const ip: {
         subnetMaskLength: number;
         numHosts: number;
         length: number;
-        contains(ip: string): boolean;
+        contains(ip: string | core.BufferLike | number): boolean;
     };
     cidr: (cidrString: string) => string;
     cidrSubnet: (cidrString: string) => {
@@ -45,7 +45,7 @@ export declare const ip: {
         subnetMaskLength: number;
         numHosts: number;
         length: number;
-        contains(ip: string): boolean;
+        contains(ip: string | core.BufferLike | number): boolean;
     };
     not: (addr: string) => string;
     or: (a: string, b: string) => string;


### PR DESCRIPTION
```js
toLong('127.0.0.1') === toLong(toBuffer('127.0.0.1'))
toBuffer(2130706433) === toBuffer(toString(2130706433))
toString(toBuffer(2130706433)) === toString(2130706433)


const sn = subnet('192.168.1.134', '255.255.255.192')

sn.contains('192.168.1.128')              // true
sn.contains(toLong('192.168.1.180'))      // true
sn.contains(toBuffer('192.168.1.180'))    // true
 ```
 